### PR TITLE
chore(hackclub.community): add GitHub Pages CNAME record for status page

### DIFF
--- a/hackclub.community.yaml
+++ b/hackclub.community.yaml
@@ -71,3 +71,8 @@ stats: # alimad.co.ltd@gmail.com U08LQFRBL6S
   - ttl: 300
     type: CNAME
     value: Alimadcorp.github.io.
+# https://github.com/hackclub-community/community-services-status
+status: # ajhalili2006@crew.recaptime.dev U07CAPBB9B5
+  - ttl: 300
+    type: CNAME
+    value: hackclub-community.github.io.


### PR DESCRIPTION
# Adding `status.hackclub.community`

## Description of changes

Add a GitHub Pages CNAME record at `status` subdomain for `hackclub.community` to get community services/infra monitoring powered by Upptime up ready to go.

## Website content/purpose
<!-- If you are adding a new subdomain, provide a quick description of the content/purpose of the website you plan to host. -->

Setting up https://upptime.js.org for @hackclub-community services and infra btw. Repository is at https://github.com/hackclub-community/community-services-status, using @hackclub-community-ops (managed by @ajhalili2006) service account for issue tracking downtimes and other automated actions.

## HQ Sponsor
<!-- If you are requesting a subdomain under `hackclub.com`, please state the name of your hq POC/sponsor: -->

_Not a HQ project, hence this is not applicable._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated status subdomain for accessing service availability information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->